### PR TITLE
fix: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+name 'gems'
+
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'gems', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -98,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -21,5 +21,6 @@ platforms:
 
 suites:
   - name: default
+    named_run_list: default
     run_list:
       - recipe[test::default]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Problem

The shared CI at `sous-chefs/.github@9.0.0` no longer installs the berkshelf gem, so `require 'chefspec/berkshelf'` aborts the entire RSpec suite before any example runs:

```
ChefSpec::Error::GemLoadError: I could not load the 'Berkshelf' gem!
```

RSpec is a required check, so nothing can merge here until this is fixed.

## Fix

Replace the Berksfile with a Policyfile, point spec_helper at `chefspec/policyfile`, and give the Kitchen suite a `named_run_list` so it resolves against the Policyfile. `default_source :supermarket` is included because this cookbook has external `depends`. Mirrors the migration already applied to rsyslog, docker and nginx.

## Verification

Full RSpec suite run locally with Cinc Workstation before opening this PR:

```
1 example, 0 failures
```

Cookstyle clean.